### PR TITLE
Major Performance Update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
 		minSdkVersion 17
 		targetSdkVersion 24
 		versionCode 21
-		versionName "1.2.1.1"
+		versionName "1.3.1"
 	}
 	buildTypes {
 		release {
@@ -34,5 +34,6 @@ dependencies {
 	compile 'com.github.ksoichiro:android-observablescrollview:1.6.0'
 	compile 'com.nineoldandroids:library:2.4.0'
 	compile 'com.github.florent37:materialimageloading:1.0.2'
+
 	compile project(':libraries:movingimageview')
 }

--- a/app/src/main/java/moe/feng/nhentai/api/BookApi.java
+++ b/app/src/main/java/moe/feng/nhentai/api/BookApi.java
@@ -158,7 +158,7 @@ public class BookApi {
 		if (!m.cacheExistsUrl(CACHE_COVER, url) && !m.createCacheFromNetwork(CACHE_COVER, url)) {
 			return null;
 		}
-		
+
 		return m.getBitmapUrl(CACHE_COVER, url);
 	}
 

--- a/app/src/main/java/moe/feng/nhentai/api/PageApi.java
+++ b/app/src/main/java/moe/feng/nhentai/api/PageApi.java
@@ -11,6 +11,7 @@ import org.jsoup.select.Elements;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 
 import moe.feng.nhentai.api.common.NHentaiUrl;
@@ -107,32 +108,33 @@ public class PageApi {
 
 	public static Bitmap getPageOriginImage(Context context, Book book, int page_num) {
 		String url = NHentaiUrl.getOriginPictureUrl(book.galleryId, String.valueOf(page_num));
-		FileCacheManager m = FileCacheManager.getInstance(context);
 
-		if (!m.cacheExistsUrl(CACHE_PAGE_IMG, url) && !m.createCacheFromNetwork(CACHE_PAGE_IMG, url)) {
+		if (!FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_IMG, url) && !FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_PAGE_IMG, url)) {
 			return null;
 		}
 
-		return m.getBitmapUrl(CACHE_PAGE_IMG, url);
+		return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_PAGE_IMG, url);
 	}
 
 	public static File getPageOriginImageFile(Context context, Book book, int page_num) {
 		String url = NHentaiUrl.getOriginPictureUrl(book.galleryId, String.valueOf(page_num));
-		FileCacheManager m = FileCacheManager.getInstance(context);
 
-		if (!m.externalPageExists(book, page_num) &&
-				!m.cacheExistsUrl(CACHE_PAGE_IMG, url) && !m.createCacheFromNetwork(CACHE_PAGE_IMG, url)) {
+		if (!FileCacheManager.getInstance(context).externalPageExists(book, page_num) &&
+				!FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_IMG, url) && !FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_PAGE_IMG, url)) {
 			return null;
 		}
 
-		return m.getBitmapAllowingExternalPic(book, page_num);
+		return FileCacheManager.getInstance(context).getBitmapAllowingExternalPic(book, page_num);
 	}
+
+    public static String getPageOriginImageURL(Context context, Book book, int page_num){
+        return NHentaiUrl.getOriginPictureUrl(book.galleryId, String.valueOf(page_num));
+    }
 
 	public static boolean isPageOriginImageLocalFileExist(Context context, Book book, int page_num) {
 		String url = NHentaiUrl.getOriginPictureUrl(book.galleryId, String.valueOf(page_num));
-		FileCacheManager m = FileCacheManager.getInstance(context);
 
-		return m.cacheExistsUrl(CACHE_PAGE_IMG, url);
+		return FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_IMG, url);
 	}
 
 }

--- a/app/src/main/java/moe/feng/nhentai/api/common/NHentaiUrl.java
+++ b/app/src/main/java/moe/feng/nhentai/api/common/NHentaiUrl.java
@@ -61,7 +61,7 @@ public class NHentaiUrl {
 	}
 
 	public static String getThumbPictureUrl(String g_id, String page_num, String file_type) {
-		return getThumbGalleryUrl(g_id) + "/" + page_num + "." + file_type;
+		return getThumbGalleryUrl(g_id) + "/" + page_num +  "." + file_type;
 	}
 
 	@Deprecated

--- a/app/src/main/java/moe/feng/nhentai/ui/BookDetailsActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/BookDetailsActivity.java
@@ -153,7 +153,7 @@ public class BookDetailsActivity extends AbsActivity implements ObservableScroll
 				);
 				setTaskDescription(taskDesc);
 			}
-			textDrawable = TextDrawable.builder().buildRect(Utility.getFirstCharacter(book.title), color);
+			textDrawable = TextDrawable.builder().buildRect(Utility.getFirstCharacter(book.getAvailableTitle()), color);
 		} else {
 			textDrawable = TextDrawable.builder().buildRect("", getResources().getColor(R.color.deep_purple_500));
 		}
@@ -1039,11 +1039,8 @@ public class BookDetailsActivity extends AbsActivity implements ObservableScroll
 
 		@Override
 		protected File doInBackground(Book... params) {
-			if (mSets.getBoolean(Settings.KEY_FULL_IMAGE_PREVIEW, false)) {
 				return PageApi.getPageOriginImageFile(BookDetailsActivity.this, params[0], 1);
-			} else {
-				return BookApi.getCoverFile(BookDetailsActivity.this, params[0]);
-			}
+
 		}
 
 		@Override

--- a/app/src/main/java/moe/feng/nhentai/ui/HomeActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/HomeActivity.java
@@ -2,6 +2,7 @@ package moe.feng.nhentai.ui;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -72,7 +73,6 @@ import moe.feng.nhentai.util.Settings;
 import moe.feng.nhentai.util.Utility;
 
 public class HomeActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener {
-
 	// View states
 	private int mSectionType = SECTION_LATEST;
 	private static final int SECTION_LATEST = 0, SECTION_FAV_TAB = 1, SECTION_FOLLOWING_ARTISTS = 2;
@@ -83,6 +83,7 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 	private boolean isFABShowing = true, isSearchBoxShowing = true;
 	private int currentY = 0;
 
+	public static Context myContext;
 	// List
 	private ObservableRecyclerView mRecyclerView;
 	private BookListRecyclerAdapter mAdapter;
@@ -129,7 +130,6 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 	private Settings mSets;
 
 	private Handler mHandler = new Handler();
-
 	public static final String TAG = HomeActivity.class.getSimpleName();
 
 	private static final int REQUEST_CODE_PERMISSION_GET = 101;
@@ -139,7 +139,7 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 		mSets = Settings.getInstance(getApplicationContext());
 		CrashHandler.init(getApplicationContext());
 		CrashHandler.register();
-
+		myContext = getApplicationContext();
 		/** Set up translucent status bar */
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
 			getWindow().getDecorView().setSystemUiVisibility(
@@ -202,6 +202,8 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 					})
 					.show();
 		}
+
+
 	}
 
 	private void onLoadMain() {
@@ -689,7 +691,8 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 				mActionBar.setTitle(R.string.item_favorite_categories);
 				mFragmentLayout.setVisibility(View.VISIBLE);
 				ViewCompat.setElevation(mToolbar, calcDimens(R.dimen.appbar_elevation));
-				if (mFragmentFavCategory == null) mFragmentFavCategory = new FavoriteCategoryFragment();
+				if (mFragmentFavCategory == null)
+					mFragmentFavCategory = new FavoriteCategoryFragment();
 				getFragmentManager().beginTransaction()
 						.replace(R.id.fragment_layout, mFragmentFavCategory)
 						.commit();
@@ -775,6 +778,11 @@ public class HomeActivity extends AppCompatActivity implements NavigationView.On
 
 	private <T extends View> T $(int id) {
 		return (T) findViewById(id);
+	}
+
+	@Override
+	public void onStart() {
+		super.onStart();
 	}
 
 	private class PageGetTask extends AsyncTask<Integer, Void, BaseMessage> {

--- a/app/src/main/java/moe/feng/nhentai/ui/adapter/GalleryPagerAdapter.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/adapter/GalleryPagerAdapter.java
@@ -21,6 +21,10 @@ public class GalleryPagerAdapter extends FragmentPagerAdapter {
 
 	@Override
 	public Fragment getItem(int position) {
+		if(position<0|| position>=book.pageCount){
+			return null;
+		}
+
 		if (fragments[position] == null) {
 			fragments[position] = BookPageFragment.newInstance(book, position + 1);
 		}
@@ -41,6 +45,10 @@ public class GalleryPagerAdapter extends FragmentPagerAdapter {
 				);
 			}
 		}
+	}
+
+	public void eraseItem(int position){
+		fragments[position] = null;
 	}
 
 }

--- a/app/src/main/res/layout/fragment_book_page.xml
+++ b/app/src/main/res/layout/fragment_book_page.xml
@@ -45,6 +45,6 @@
     <ImageView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/image_view"/>
+        android:id="@+id/image_view" />
 
 </FrameLayout>


### PR DESCRIPTION
Overall: Reduced Memory Footprint, Better Fragments Usage, No More FC´s on doujins with a lot of pages

PageApi -> Dont use local variables
PageApi -> Added getPageOriginImageURL if we ever move to Picasso or other

FileCacheManager -> openCacheStreamUrl and openCacheStream now return FileInputStream
FileCacheManager -> getBitmap update to return images in standard quality (WIP)(Memory Efficiency)

GalleryPagerAdapter-> added eraseItem to delete fragments
GalleryPagerAdapter -> Check bounds to return only valid fragments

BookPageFragment -> Small fixes to onPause and onResume (Better Memory Clearing)
BookPageFragment -> Always use same Bitmap

BookDetailsActivity -> Always return the biggest Image (Looks Better)

GalleryActivity -> Logic to only mantain 3 images (current, previous, next) this reduces a lot the footprint of the App. Fixes FC on largest doujins (Anthologies, tankoubon)  (WIP)(Needs Testing)

HomeActivity -> Small Cleanups