### PR TITLE
Better Memory Handling and don´t re-download images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
 		minSdkVersion 17
 		targetSdkVersion 24
 		versionCode 21
-		versionName "1.3.1"
+		versionName "1.3.2"
 	}
 	buildTypes {
 		release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
 	    <activity
 		    android:name=".ui.GalleryActivity"
 		    android:label="@string/activity_gallery"
+            android:configChanges="orientation|keyboardHidden|screenSize"
 		    android:theme="@style/Theme.NHBooks.Dark.Translucent">
 		    <intent-filter>
 			    <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/moe/feng/nhentai/api/PageApi.java
+++ b/app/src/main/java/moe/feng/nhentai/api/PageApi.java
@@ -110,22 +110,41 @@ public class PageApi {
 	public static Bitmap getPageOriginImage(Context context, Book book, int page_num) {
 		String url = NHentaiUrl.getOriginPictureUrl(book.galleryId, String.valueOf(page_num));
 
-		if (!FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_IMG, url) && !FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_PAGE_IMG, url)) {
-			return null;
+
+        if (FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_IMG, url)){
+            Log.d(TAG, "getPageOriginImage: Loaded from cache");
+            return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_PAGE_IMG, url);
+        }
+        else if(FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_PAGE_IMG, url)) {
+            Log.d(TAG, "getPageOriginImage: Downloaded from web");
+			return  FileCacheManager.getInstance(context).getBitmapUrl(CACHE_PAGE_IMG, url);
 		}
 
-		return FileCacheManager.getInstance(context).getBitmapUrl(CACHE_PAGE_IMG, url);
+        else{
+            return null;
+        }
+
 	}
 
 	public static File getPageOriginImageFile(Context context, Book book, int page_num) {
 		String url = NHentaiUrl.getOriginPictureUrl(book.galleryId, String.valueOf(page_num));
 
-		if (!FileCacheManager.getInstance(context).externalPageExists(book, page_num) &&
-				!FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_IMG, url) && !FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_PAGE_IMG, url)) {
-			return null;
-		}
+		if (FileCacheManager.getInstance(context).externalPageExists(book, page_num)){
+            Log.d(TAG, "getPageOriginImage: Loaded from external");
+           return FileCacheManager.getInstance(context).getBitmapAllowingExternalPic(book, page_num);
+        }
 
-		return FileCacheManager.getInstance(context).getBitmapAllowingExternalPic(book, page_num);
+        else if (FileCacheManager.getInstance(context).cacheExistsUrl(CACHE_PAGE_IMG, url)){
+            Log.d(TAG, "getPageOriginImage: Loaded from cache");
+            return FileCacheManager.getInstance(context).getBitmapAllowingExternalPic(book, page_num);
+        }
+        else if (FileCacheManager.getInstance(context).createCacheFromNetwork(CACHE_PAGE_IMG, url)){
+            Log.d(TAG, "getPageOriginImage: Downloaded from web");
+            return FileCacheManager.getInstance(context).getBitmapAllowingExternalPic(book, page_num);
+		}
+        else {
+            return null;
+        }
 	}
 
     public static String getPageOriginImageURL(Context context, Book book, int page_num){

--- a/app/src/main/java/moe/feng/nhentai/ui/BookDetailsActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/BookDetailsActivity.java
@@ -9,7 +9,7 @@ import android.app.PendingIntent;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.net.Uri;
+import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
@@ -655,6 +655,7 @@ public class BookDetailsActivity extends AbsActivity implements ObservableScroll
 			intent.putExtra("position", fromPosition);
 			setResult(RESULT_HAVE_FAV, intent);
 		}
+		mImageView.setImageBitmap(null);
 		super.onBackPressed();
 	}
 
@@ -1037,21 +1038,18 @@ public class BookDetailsActivity extends AbsActivity implements ObservableScroll
 
 	}
 
-	private class CoverTask extends AsyncTask<Book, Void, String> {
+	private class CoverTask extends AsyncTask<Book, Void, Bitmap> {
 
 		@Override
-		protected String doInBackground(Book... params) {
-				return PageApi.getPageOriginImageURL(BookDetailsActivity.this, params[0], 1);
+		protected Bitmap doInBackground(Book... params) {
+				return PageApi.getPageOriginImage(getApplicationContext(), params[0], 1);
 
 		}
 
 		@Override
-		protected void onPostExecute(String result) {
-			mImageView.setImageBitmap(null);
-			Picasso.with(getApplicationContext())
-					.load(Uri.parse(result))
-					.into(mImageView);
-
+		protected void onPostExecute(Bitmap result) {
+			mImageView.setImageDrawable(null);
+			mImageView.setImageBitmap(result);
 			mImageView.invalidate();
 
 

--- a/app/src/main/java/moe/feng/nhentai/ui/RandomActivity.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/RandomActivity.java
@@ -1,6 +1,7 @@
 package moe.feng.nhentai.ui;
 
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -15,12 +16,7 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.github.florent37.materialimageloading.MaterialImageLoading;
 import com.google.gson.Gson;
-import com.squareup.picasso.Callback;
-import com.squareup.picasso.Picasso;
-
-import java.io.File;
 import java.util.Random;
 
 import moe.feng.nhentai.R;
@@ -190,33 +186,18 @@ public class RandomActivity extends AbsActivity {
 		}
 	};
 
-	private class CoverTask extends AsyncTask<Book, Void, File> {
+	private class CoverTask extends AsyncTask<Book, Void, Bitmap> {
 
 		@Override
-		protected File doInBackground(Book... params) {
-			if (mSets.getBoolean(Settings.KEY_FULL_IMAGE_PREVIEW, false)) {
-				return PageApi.getPageOriginImageFile(RandomActivity.this, params[0], 1);
-			} else {
-				return BookApi.getCoverFile(RandomActivity.this, params[0]);
-			}
+		protected Bitmap doInBackground(Book... params) {
+			return PageApi.getPageOriginImage(getApplicationContext(), params[0],1);
 		}
 
 		@Override
-		protected void onPostExecute(File result) {
+		protected void onPostExecute(Bitmap result) {
 			mCoverView.setImageBitmap(null);
-			Picasso.with(getApplicationContext())
-					.load(result)
-					.into(mCoverView, new Callback() {
-						@Override
-						public void onSuccess() {
-							MaterialImageLoading.animate(mCoverView).setDuration(2000).start();
-						}
-
-						@Override
-						public void onError() {
-
-						}
-					});
+			mCoverView.setImageBitmap(result);
+			mCoverView.invalidate();
 		}
 	}
 
@@ -267,4 +248,11 @@ public class RandomActivity extends AbsActivity {
 		}
 	}
 
+	@Override
+	public void onDestroy(){
+		super.onDestroy();
+
+		mCoverView.setImageBitmap(null);
+		mLangFieldView.setImageBitmap(null);
+	}
 }

--- a/app/src/main/java/moe/feng/nhentai/ui/adapter/GalleryPagerAdapter.java
+++ b/app/src/main/java/moe/feng/nhentai/ui/adapter/GalleryPagerAdapter.java
@@ -28,12 +28,19 @@ public class GalleryPagerAdapter extends FragmentPagerAdapter {
 		if (fragments[position] == null) {
 			fragments[position] = BookPageFragment.newInstance(book, position + 1);
 		}
+
 		return fragments[position];
 	}
 
 	@Override
 	public int getCount() {
 		return book.pageCount;
+	}
+
+	public void eraseItem(int position){
+		fragments[position].getFragmentManager().beginTransaction().remove(fragments[position]).commit();
+		fragments[position]=null;
+
 	}
 
 	public void notifyPageImageLoaded(int position, boolean isSucceed) {
@@ -46,9 +53,4 @@ public class GalleryPagerAdapter extends FragmentPagerAdapter {
 			}
 		}
 	}
-
-	public void eraseItem(int position){
-		fragments[position] = null;
-	}
-
 }


### PR DESCRIPTION
Overall: More memory management on gallery activity and book page fragments, couple UI fixes, couple logic changes for getting image

PageApi ->Change logic to only download images if not present. Past logic checked if existed and re-downloaded them at the same time

FileCacheManager -> Introduces First Version of custom in sample size

GalleryPagerAdapter-> Added eraseItem function (Erase fragments for better memory handling)

BookPageFragment-> More memory cleaning stuff (No more memory leaks in this department :D)

BookDetailsActivity -> Change Picasso for manual loading (Fixes some devices not showing image)

GalleryActivity -> Added on ConfigurationChanged function and logic (Fixes FC´s when rotating)
GalleryActivity -> Forced Garbage Collector every 5 swipes (Free memory faster)

RandomActivity -> Change Picasso for manual loading (Fixes some devices not showing image)

AndroidManifest -> enable onConfigurationChanged for GalleryActivity

Build.Gradle -> Bump to 1.3.2